### PR TITLE
Mario Kart World

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## Version 2.8
+
+### Added
+
+- Added Mario Kart World information. Both Grand Prix and Knockout Tour races available
+
+### Changed
+
+- changed database to add "type" column for cups. Keeps Cups and Rallies separate
+
 ## Version 2.7
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,12 +23,19 @@ Host your own Mario Kart Tournament with this web app. Features include the abil
 
 ## Install
 
-Clone the repository and download the required libraries. Note that `sudo` is needed since we'll need root to bind to a socket later. It's assumed you have a working version of Python 3 installed along with [Pip](https://pypi.org/project/pip/).
+Clone the repository and download the required libraries. It's assumed you have a working version of Python 3 installed along with [Pip](https://pypi.org/project/pip/).
 
 ```
 git clone https://github.com/robweber/mario-kart-tournament.git
 cd mario-kart-tournament
-sudo -H pip3 install -r install/requirements.txt
+
+# create a virtual environment
+python3 -m venv --system-site-packages .venv
+source .venv/bin/activate
+
+# download required libs
+pip3 install setuptools -U
+pip3 install -r install/requirements.txt
 ```
 
 The database schema resides in `install/database.sql` and an SQLite database is automatically generated if it doesn't exist when the program loads.
@@ -38,7 +45,7 @@ The database schema resides in `install/database.sql` and an SQLite database is 
 Once the required features have been installed you can run the program with default options to start the web service on port 5000. Access it via a browser with `http://server_ip:5000/`.
 
 ```
-sudo python3 main.py
+python3 main.py
 
 ```
 
@@ -137,12 +144,17 @@ There are a few questions, caveats or _gotchas_ that made sense to document as F
 >* Mario Kart 8 (Wii U version)
 >* Mario Kart 8 Deluxe (Switch version)
 >* Mario Kart Wii (Wii version)
+>* Mario Kart World (Switch 2 version)
 
 >These were deemed the best for tournament play (by me) since they were available on multiplayer consoles. It is possible to add more games to the database as it's just an SQLite file. You can add it yourself (via SQL) or open an [Issue](https://github.com/robweber/mario-kart-tournament/issues) if you'd like to see one added that doesn't exist.
 
 6. In Mario Kart 8 Deluxe I don't have all the Cups listed.
 
 >Mario Kart 8 Deluxe for the Switch is a bit of an outlier in that it has additional "pay to play" type bonus tracks called the [Booster Course Pass](https://mariokart8.nintendo.com/booster-course-pass/). You have to either pay for these outright or subscribe to Nintendo's Online membership system. If you don't have these Cups available simply deselect them from play prior to starting the tournament.
+
+7. Can I run a tournament using Knockout Tours in Mario Kart World? 
+
+>Yes, you can. Mario Kart World has a game mode using rallies that are different from the normal "Grand Prix" mode. Each Rally is a set of tracks you race consecutively with no breaks and players are eliminated at specific checkpoints if you are in the last four places. Running a tournament in Knockout Tour mode just select Mario Kart World as the game. De-select all the Grand Prix Cup races and only highlight the Rally races. When the tournament starts it will select from the list of Rallies for each match-up. 
 
 ## Thanks
 

--- a/install/database.sql
+++ b/install/database.sql
@@ -1,19 +1,19 @@
 BEGIN TRANSACTION;
-DROP TABLE IF EXISTS "games";
-CREATE TABLE IF NOT EXISTS "games" (
+DROP TABLE IF EXISTS "cups";
+CREATE TABLE "cups" (
 	"id"	INTEGER,
 	"name"	TEXT NOT NULL,
+	"type"	TEXT,
 	PRIMARY KEY("id" AUTOINCREMENT)
 );
-DROP TABLE IF EXISTS "settings";
-CREATE TABLE IF NOT EXISTS "settings" (
+DROP TABLE IF EXISTS "difficulty_modes";
+CREATE TABLE "difficulty_modes" (
 	"id"	INTEGER,
-	"name"	TEXT NOT NULL,
-	"value"	TEXT NOT NULL,
+	"name"	TEXT,
 	PRIMARY KEY("id" AUTOINCREMENT)
 );
 DROP TABLE IF EXISTS "drivers";
-CREATE TABLE IF NOT EXISTS "drivers" (
+CREATE TABLE "drivers" (
 	"id"	INTEGER,
 	"name"	TEXT NOT NULL,
 	"phone"	TEXT,
@@ -23,8 +23,26 @@ CREATE TABLE IF NOT EXISTS "drivers" (
 	"active"	TEXT DEFAULT 'false',
 	PRIMARY KEY("id" AUTOINCREMENT)
 );
+DROP TABLE IF EXISTS "game_cup";
+CREATE TABLE "game_cup" (
+	"game_id"	INTEGER,
+	"cup_id"	INTEGER,
+	PRIMARY KEY("game_id","cup_id")
+);
+DROP TABLE IF EXISTS "game_difficulty";
+CREATE TABLE "game_difficulty" (
+	"game_id"	INTEGER,
+	"mode_id"	INTEGER,
+	PRIMARY KEY("game_id","mode_id")
+);
+DROP TABLE IF EXISTS "games";
+CREATE TABLE "games" (
+	"id"	INTEGER,
+	"name"	TEXT NOT NULL,
+	PRIMARY KEY("id" AUTOINCREMENT)
+);
 DROP TABLE IF EXISTS "matches";
-CREATE TABLE IF NOT EXISTS "matches" (
+CREATE TABLE "matches" (
 	"id"	INTEGER,
 	"driver_id"	INTEGER,
 	"score"	INTEGER,
@@ -32,49 +50,49 @@ CREATE TABLE IF NOT EXISTS "matches" (
 	"match_num"	INTEGER,
 	PRIMARY KEY("id" AUTOINCREMENT)
 );
-DROP TABLE IF EXISTS "game_cup";
-CREATE TABLE IF NOT EXISTS "game_cup" (
-	"game_id"	INTEGER,
-	"cup_id"	INTEGER,
-	PRIMARY KEY("game_id","cup_id")
-);
-DROP TABLE IF EXISTS "cups";
-CREATE TABLE IF NOT EXISTS "cups" (
+DROP TABLE IF EXISTS "settings";
+CREATE TABLE "settings" (
 	"id"	INTEGER,
 	"name"	TEXT NOT NULL,
+	"value"	TEXT NOT NULL,
 	PRIMARY KEY("id" AUTOINCREMENT)
 );
-DROP TABLE IF EXISTS "difficulty_modes";
-CREATE TABLE IF NOT EXISTS "difficulty_modes" (
-	"id"	INTEGER,
-	"name"	TEXT,
-	PRIMARY KEY("id" AUTOINCREMENT)
-);
-DROP TABLE IF EXISTS "game_difficulty";
-CREATE TABLE IF NOT EXISTS "game_difficulty" (
-	"game_id"	INTEGER,
-	"mode_id"	INTEGER,
-	PRIMARY KEY("game_id","mode_id")
-);
-INSERT INTO "games" VALUES (1,'Mario Kart Wii'),
- (2,'Mario Kart 64'),
- (3,'Super Mario Kart - SNES'),
- (4,'Mario Kart: Double Dash!'),
- (6,'Mario Kart 8 Deluxe'),
- (7,'Mario Kart 8'),
- (8, 'Mario Kart 7');
-INSERT INTO "settings" VALUES (1,'tournament_active','false'),
- (2,'active_game','1'),
- (3,'player_1','14'),
- (4,'player_2','15'),
- (5,'active_cup','Shell'),
- (6,'game_over','false'),
- (7,'send_sms','false'),
- (8,'active_match','1'),
- (9,'active_level','1'),
- (10,'game_mode','50cc'),
- (11,'admin_pin',''),
- (12,'selected_cups','[1, 2, 4, 5, 6, 7, 8, 9]');
+INSERT INTO "cups" VALUES (1,'Mushroom','Cup'),
+ (2,'Flower','Cup'),
+ (4,'Star','Cup'),
+ (5,'Special','Cup'),
+ (6,'Shell','Cup'),
+ (7,'Banana','Cup'),
+ (8,'Leaf','Cup'),
+ (9,'Lightning','Cup'),
+ (25,'Egg','Cup'),
+ (26,'Triforce','Cup'),
+ (27,'Crossing','Cup'),
+ (28,'Bell','Cup'),
+ (29,'Golden Dash','Cup'),
+ (30,'Lucky Cat','Cup'),
+ (31,'Turnip','Cup'),
+ (32,'Propeller','Cup'),
+ (33,'Rock','Cup'),
+ (34,'Moon','Cup'),
+ (35,'Fruit','Cup'),
+ (36,'Boomerang','Cup'),
+ (37,'Feather','Cup'),
+ (38,'Cherry','Cup'),
+ (39,'Golden','Rally'),
+ (40,'Ice','Rally'),
+ (41,'Moon','Rally'),
+ (42,'Spiny','Rally'),
+ (43,'Cherry','Rally'),
+ (44,'Acorn','Rally'),
+ (45,'Cloud','Rally'),
+ (46,'Heart','Rally');
+INSERT INTO "difficulty_modes" VALUES (1,'50cc'),
+ (2,'100cc'),
+ (3,'150cc'),
+ (4,'Mirror Mode'),
+ (5,'200cc'),
+ (6,'Extra');
 INSERT INTO "game_cup" VALUES (1,1),
  (1,2),
  (1,4),
@@ -136,35 +154,23 @@ INSERT INTO "game_cup" VALUES (1,1),
  (8,6),
  (8,7),
  (8,8),
- (8,9);
-INSERT INTO "cups" VALUES (1,'Mushroom'),
- (2,'Flower'),
- (4,'Star'),
- (5,'Special'),
- (6,'Shell'),
- (7,'Banana'),
- (8,'Leaf'),
- (9,'Lightning'),
- (25,'Egg'),
- (26,'Triforce'),
- (27,'Crossing'),
- (28,'Bell'),
- (29,'Golden Dash'),
- (30,'Lucky Cat'),
- (31,'Turnip'),
- (32,'Propeller'),
- (33,'Rock'),
- (34,'Moon'),
- (35,'Fruit'),
- (36,'Boomerang'),
- (37, 'Feather'),
- (38, 'Cherry');
-INSERT INTO "difficulty_modes" VALUES (1,'50cc'),
- (2,'100cc'),
- (3,'150cc'),
- (4,'Mirror Mode'),
- (5,'200cc'),
- (6,'Extra');
+ (8,9),
+ (9,1),
+ (9,2),
+ (9,3),
+ (9,6),
+ (9,7),
+ (9,8),
+ (9,9),
+ (9,5),
+ (9,39),
+ (9,40),
+ (9,41),
+ (9,42),
+ (9,43),
+ (9,44),
+ (9,45),
+ (9,46);
 INSERT INTO "game_difficulty" VALUES (1,1),
  (1,2),
  (1,3),
@@ -198,5 +204,29 @@ INSERT INTO "game_difficulty" VALUES (1,1),
  (8,1),
  (8,2),
  (8,3),
- (8,4);
+ (8,4),
+ (9,1),
+ (9,2),
+ (9,3),
+ (9,4);
+INSERT INTO "games" VALUES (1,'Mario Kart Wii'),
+ (2,'Mario Kart 64'),
+ (3,'Super Mario Kart - SNES'),
+ (4,'Mario Kart: Double Dash!'),
+ (6,'Mario Kart 8 Deluxe'),
+ (7,'Mario Kart 8'),
+ (8,'Mario Kart 7'),
+ (9,'Mario Kart World');
+INSERT INTO "settings" VALUES (1,'tournament_active','false'),
+ (2,'active_game','1'),
+ (3,'player_1','14'),
+ (4,'player_2','15'),
+ (5,'active_cup','Shell'),
+ (6,'game_over','false'),
+ (7,'send_sms','false'),
+ (8,'active_match','1'),
+ (9,'active_level','1'),
+ (10,'game_mode','50cc'),
+ (11,'admin_pin',''),
+ (12,'selected_cups','[1, 2, 4, 5, 6, 7, 8, 9]');
 COMMIT;

--- a/install/database.sql
+++ b/install/database.sql
@@ -86,7 +86,9 @@ INSERT INTO "cups" VALUES (1,'Mushroom','Cup'),
  (43,'Cherry','Rally'),
  (44,'Acorn','Rally'),
  (45,'Cloud','Rally'),
- (46,'Heart','Rally');
+ (46,'Heart','Rally'),
+ (47,'Acorn','Cup'),
+ (48,'Spiny','Cup');
 INSERT INTO "difficulty_modes" VALUES (1,'50cc'),
  (2,'100cc'),
  (3,'150cc'),
@@ -170,7 +172,9 @@ INSERT INTO "game_cup" VALUES (1,1),
  (9,43),
  (9,44),
  (9,45),
- (9,46);
+ (9,46),
+ (6,47),
+ (6,48);
 INSERT INTO "game_difficulty" VALUES (1,1),
  (1,2),
  (1,3),

--- a/install/mario-kart-tournament.service
+++ b/install/mario-kart-tournament.service
@@ -4,7 +4,7 @@ Description=Mario Kart Tournament
 [Service]
 User=root
 WorkingDirectory=/home/user/mario-kart-tournament/
-ExecStart=/usr/bin/python3 main.py
+ExecStart=/home/user/mario-kart-tournament/.venv/bin/python3 /home/user/mario-kart-tournament/main.py
 
 [Install]
 WantedBy=multi-user.target

--- a/main.py
+++ b/main.py
@@ -172,7 +172,9 @@ def admin():
             # select all cups from the new game
             new_game_cups = db.find_all_cups(request.form['active_game'])
             for c in new_game_cups:
-                cups.append(int(c['id']))
+                # ignore rallies by default
+                if(c['type'] == 'Cup'):
+                    cups.append(int(c['id']))
 
         else:
             db.update_setting('game_mode', request.form['game_mode'])

--- a/main.py
+++ b/main.py
@@ -442,7 +442,7 @@ def update_active_match(player1, player2, level, match, active_game):
     # get a cup for them to play
     cups = db.find_selected_cups(active_game.get_id(), active_game.get_cups())
     cup_id = random.randint(0, len(cups) - 1)
-    db.update_setting('active_cup', cups[cup_id]['name'])
+    db.update_setting('active_cup', f"{cups[cup_id]['name']} {cups[cup_id]['type']}")
 
 
 def find_next_match(level, match):

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -14,7 +14,7 @@ AVATARS = ['baby_daisy', 'baby_luigi', 'baby_mario', 'baby_peach', 'baby_rosalin
 # some pre-canned queries to avoid re-typeing
 ACTIVE_GAME_QUERY = "select id, name from games where id = (select value from settings where name = ?)"
 CREATE_MATCH_STATEMENT = "insert into matches (driver_id, bracket_level, match_num, score) values (?, ?, ?, -1)"
-FIND_ALL_CUPS_QUERY = "select cups.id as id, cups.name as name from cups join game_cup on cups.id = game_cup.cup_id join games on games.id = game_cup.game_id where games.id = ? order by cups.id asc"  # noqa
+FIND_ALL_CUPS_QUERY = "select cups.id as id, cups.name as name, cups.type as type from cups join game_cup on cups.id = game_cup.cup_id join games on games.id = game_cup.game_id where games.id = ? order by cups.id asc"  # noqa
 FIND_DIFFICULTY_QUERY = "select difficulty_modes.name as name from difficulty_modes join game_difficulty on difficulty_modes.id = game_difficulty.mode_id join games on games.id = game_difficulty.game_id where games.id = ?"  # noqa
 
 

--- a/web/templates/admin.html
+++ b/web/templates/admin.html
@@ -24,7 +24,7 @@
       <label for="game_mode">Selected Cups</label>
       <select name="game_cups" class="form-control" multiple>
         {% for c in cups %}
-        <option value="{{ c['id'] }}" {{ 'selected' if active_game.cup_selected(c['id']) }}>{{ c['name'] }}</option>
+        <option value="{{ c['id'] }}" {{ 'selected' if active_game.cup_selected(c['id']) }}>{{ c['name'] }} {{ c['type'] }}</option>
         {% endfor %}
       </select>
   </div>
@@ -39,6 +39,7 @@
       </select>
   </div>
 
+<!--
 	<div class="form-group">
 	    <label for="send_sms">Send SMS</label>
       <select name="send_sms" class="form-control">
@@ -46,7 +47,8 @@
         <option value="false" {{ 'selected' if settings['send_sms'] == 'false' }}>No</option>
       </select>
 	</div>
-
+-->
+  <input type="hidden" name="send_sms" value="false" />
 	<div class="form-group">
     <input type="submit" value="Update Settings" class="btn btn-large btn-info" />
 	</div>
@@ -69,7 +71,7 @@
     </tr>
     <tr>
       <td><a href="/admin/winner/{{ player1['id'] }}" class="btn btn-block btn-primary">WINNER</a></td>
-      <td><h2 align="center" class="text-primary">{{ settings['active_cup'] }} Cup</h2></td>
+      <td><h2 align="center" class="text-primary">{{ settings['active_cup'] }}</h2></td>
       <td><a href="/admin/winner/{{ player2['id'] }}" class="btn btn-block btn-primary">WINNER</a></td>
     </tr>
   </table>

--- a/web/templates/scoreboard.html
+++ b/web/templates/scoreboard.html
@@ -64,7 +64,7 @@ function refresh_info(){
 
         // display the cup information
         row2 = tr.clone();
-        row2.append('<td colspan="3"><h2 align="center" class="text-primary">' + data.settings.active_cup + ' Cup</h2></td>');
+        row2.append('<td colspan="3"><h2 align="center" class="text-primary">' + data.settings.active_cup + '</h2></td>');
 
         table.append(row1);
         table.append(row2);


### PR DESCRIPTION
This PR adds Mario Kart World for the Switch 2. In addition to cups, rallies are also added.  

Rallies are a new game mechanic called the "Knockout Tour" in MK World. For simplicity these are implemented the same as cups for the normal Grand Prix mode. If running a tournament using the Knockout Tour, just deselect the normal Cups from the rotation and leave the Rallies selected. By default Grand Prix mode is the assumed tournament mode so Rallies are excluded unless specifically selected. 